### PR TITLE
test: stories for every missing presenter (+ register all libs)

### DIFF
--- a/libs/alphaTiles/feature-about/eslint.config.mjs
+++ b/libs/alphaTiles/feature-about/eslint.config.mjs
@@ -15,6 +15,8 @@ export default [
             '{projectRoot}/src/**/*.test.tsx',
             '{projectRoot}/src/**/*.spec.ts',
             '{projectRoot}/src/**/*.spec.tsx',
+            '{projectRoot}/src/**/*.stories.tsx',
+            '{projectRoot}/src/**/*.stories.ts',
           ],
         },
       ],

--- a/libs/alphaTiles/feature-about/src/AboutScreen.stories.tsx
+++ b/libs/alphaTiles/feature-about/src/AboutScreen.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AboutScreen } from './AboutScreen';
+
+const meta: Meta<typeof AboutScreen> = {
+  title: 'alphaTiles/feature-about/AboutScreen',
+  component: AboutScreen,
+  args: {
+    onBack: () => undefined,
+    versionLabel: 'Version 1.2.3',
+    localName: 'AlphaTiles',
+    langPlusCountry: 'English (United States)',
+    creditsHeading: 'Credits',
+    credits:
+      'Designed and built by the AlphaTiles team in collaboration with the language community.',
+    showSecondaryCredits: false,
+    secondaryCredits: '',
+    showEmail: true,
+    emailLabel: 'contact@alphatilesapps.org',
+    showPrivacy: true,
+    privacyLabel: 'Privacy Policy',
+    onEmailTap: () => undefined,
+    onPrivacyTap: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AboutScreen>;
+
+export const Default: Story = {};
+
+export const WithSecondaryCredits: Story = {
+  args: {
+    showSecondaryCredits: true,
+    secondaryCredits:
+      'Audio recordings courtesy of the regional literacy programme. Tile illustrations by community contributors.',
+  },
+};
+
+export const NoOptionalLinks: Story = {
+  args: {
+    showEmail: false,
+    showPrivacy: false,
+  },
+};

--- a/libs/alphaTiles/feature-choose-player/src/lib/ChoosePlayerScreen.stories.tsx
+++ b/libs/alphaTiles/feature-choose-player/src/lib/ChoosePlayerScreen.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ChoosePlayerScreen } from './ChoosePlayerScreen';
+import type { PlayerCardData } from './ChoosePlayerScreen';
+
+function makePlayer(
+  id: string,
+  name: string,
+  avatar: number,
+  deleteState: PlayerCardData['deleteState'] = 'idle',
+): PlayerCardData {
+  return { id, name, avatar, deleteState };
+}
+
+const meta: Meta<typeof ChoosePlayerScreen> = {
+  title: 'alphaTiles/feature-choose-player/ChoosePlayerScreen',
+  component: ChoosePlayerScreen,
+  args: {
+    heading: 'Choose your player',
+    avatarCount: 12,
+    addLabel: '+',
+    onSelectPlayer: () => undefined,
+    onAddPlayer: () => undefined,
+    onRequestDelete: () => undefined,
+    onConfirmDelete: () => undefined,
+    a11y: {
+      selectPlayer: (n) => `Select ${n}`,
+      delete: 'Delete player',
+      confirmDelete: 'Confirm delete',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ChoosePlayerScreen>;
+
+export const ThreePlayers: Story = {
+  args: {
+    players: [
+      makePlayer('1', 'Anna', 0),
+      makePlayer('2', 'Bilal', 3),
+      makePlayer('3', 'Carmen', 7),
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: { players: [] },
+};
+
+export const DeleteArmed: Story = {
+  args: {
+    players: [
+      makePlayer('1', 'Anna', 0),
+      makePlayer('2', 'Bilal', 3, 'armed'),
+      makePlayer('3', 'Carmen', 7),
+    ],
+  },
+};
+
+export const DeleteConfirm: Story = {
+  args: {
+    players: [
+      makePlayer('1', 'Anna', 0),
+      makePlayer('2', 'Bilal', 3, 'confirm'),
+      makePlayer('3', 'Carmen', 7),
+    ],
+  },
+};

--- a/libs/alphaTiles/feature-game-menu/src/GameMenuScreen.stories.tsx
+++ b/libs/alphaTiles/feature-game-menu/src/GameMenuScreen.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { GameMenuScreen } from './GameMenuScreen';
+import type { DoorItem } from '@shared/ui-door-grid';
+
+const COLORS = ['#9C27B0', '#2196F3', '#F44336', '#4CAF50', '#E91E63', '#FFEB3B', '#FF9800', '#3F51B5'];
+
+function makeDoors(n: number, visualForIdx: (i: number) => DoorItem['visual'] = () => 'not-started'): DoorItem[] {
+  return Array.from({ length: n }, (_, i) => ({
+    index: i,
+    colorHex: COLORS[i % COLORS.length],
+    visual: visualForIdx(i),
+    a11yLabel: `Game ${i + 1}`,
+  }));
+}
+
+const meta: Meta<typeof GameMenuScreen> = {
+  title: 'alphaTiles/feature-game-menu/GameMenuScreen',
+  component: GameMenuScreen,
+  args: {
+    page: 1,
+    totalPages: 1,
+    playerName: 'Anna',
+    playerAvatarSrc: null,
+    score: 42,
+    showShare: true,
+    showResources: true,
+    showAbout: true,
+    showAudioInstructions: true,
+    layout: 'classic',
+    onDoorPress: () => undefined,
+    onPrev: () => undefined,
+    onNext: () => undefined,
+    onBack: () => undefined,
+    onAbout: () => undefined,
+    onShare: () => undefined,
+    onResources: () => undefined,
+    onAudioInstructions: () => undefined,
+    onToggleLayout: () => undefined,
+    a11y: {
+      prev: 'Previous page',
+      next: 'Next page',
+      back: 'Back',
+      about: 'About',
+      share: 'Share',
+      resources: 'Resources',
+      audioInstructions: 'Audio instructions',
+      score: 'Score',
+      toggleLayout: 'Toggle layout',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GameMenuScreen>;
+
+export const Default: Story = {
+  args: { doors: makeDoors(12) },
+};
+
+export const WithProgress: Story = {
+  args: {
+    doors: makeDoors(12, (i) =>
+      i < 3 ? 'mastery' : i < 6 ? 'in-process' : 'not-started',
+    ),
+    score: 240,
+  },
+};
+
+export const Paged: Story = {
+  args: {
+    doors: makeDoors(12),
+    page: 2,
+    totalPages: 4,
+  },
+};
+
+export const NoOptionalControls: Story = {
+  args: {
+    doors: makeDoors(12),
+    showShare: false,
+    showResources: false,
+    showAbout: false,
+    showAudioInstructions: false,
+  },
+};

--- a/libs/alphaTiles/feature-game-menu/src/GameMenuScreenModern.stories.tsx
+++ b/libs/alphaTiles/feature-game-menu/src/GameMenuScreenModern.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { GameMenuScreenModern } from './GameMenuScreenModern';
+import type { DoorData } from './useDoors';
+
+const COLORS = ['#9C27B0', '#2196F3', '#F44336', '#4CAF50', '#E91E63', '#FFEB3B', '#FF9800', '#3F51B5'];
+const CLASS_KEYS = ['china', 'mexico', 'peru', 'brazil', 'italy', 'japan', 'thailand', 'romania'];
+
+function makeDoors(
+  n: number,
+  visualForIdx: (i: number) => DoorData['visual'] = () => 'not-started',
+): DoorData[] {
+  return Array.from({ length: n }, (_, i) => ({
+    index: i,
+    classKey: CLASS_KEYS[i % CLASS_KEYS.length],
+    challengeLevel: (i % 3) + 1,
+    colorHex: COLORS[i % COLORS.length],
+    noRightWrong: false,
+    trackerCount: i % 13,
+    visual: visualForIdx(i),
+    textColorHex: undefined,
+  }));
+}
+
+const meta: Meta<typeof GameMenuScreenModern> = {
+  title: 'alphaTiles/feature-game-menu/GameMenuScreenModern',
+  component: GameMenuScreenModern,
+  args: {
+    playerName: 'Anna',
+    playerAvatarSrc: null,
+    score: 42,
+    showShare: true,
+    showResources: true,
+    showAbout: true,
+    showAudioInstructions: true,
+    layout: 'modern',
+    onDoorPress: () => undefined,
+    onBack: () => undefined,
+    onAbout: () => undefined,
+    onShare: () => undefined,
+    onResources: () => undefined,
+    onAudioInstructions: () => undefined,
+    onToggleLayout: () => undefined,
+    a11y: {
+      back: 'Back',
+      about: 'About',
+      share: 'Share',
+      resources: 'Resources',
+      audioInstructions: 'Audio instructions',
+      score: 'Score',
+      toggleLayout: 'Toggle layout',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GameMenuScreenModern>;
+
+export const Default: Story = {
+  args: { allDoors: makeDoors(12) },
+};
+
+export const ManyDoors: Story = {
+  args: { allDoors: makeDoors(40) },
+};
+
+export const Mixed: Story = {
+  args: {
+    allDoors: makeDoors(20, (i) =>
+      i % 3 === 0 ? 'mastery' : i % 3 === 1 ? 'in-process' : 'not-started',
+    ),
+    score: 180,
+  },
+};

--- a/libs/alphaTiles/feature-game-shell/src/lib/GameShellScreen.stories.tsx
+++ b/libs/alphaTiles/feature-game-shell/src/lib/GameShellScreen.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Text, View } from 'react-native';
+import { GameShellScreen } from './GameShellScreen';
+
+const ICON = (seed: string) => ({ uri: `https://picsum.photos/seed/${seed}/64` });
+
+const ICONS = {
+  back: ICON('back'),
+  instructions: ICON('inst'),
+  advance: ICON('adv'),
+  advanceInactive: ICON('adv-i'),
+  trackerComplete: ICON('tc'),
+  trackerIncomplete: ICON('ti'),
+};
+
+const FILLER = (
+  <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#FAFAFA' }}>
+    <Text style={{ fontSize: 24 }}>game body slot</Text>
+  </View>
+);
+
+const trackers = (n: number): ('complete' | 'incomplete')[] =>
+  Array.from({ length: 12 }, (_, i) => (i < n ? 'complete' : 'incomplete'));
+
+const meta: Meta<typeof GameShellScreen> = {
+  title: 'alphaTiles/feature-game-shell/GameShellScreen',
+  component: GameShellScreen,
+  args: {
+    score: 12,
+    gameNumber: 3,
+    gameColor: '#1565C0',
+    challengeLevel: 1,
+    trackerCount: 4,
+    trackerStates: trackers(4),
+    interactionLocked: false,
+    showInstructionsButton: true,
+    advanceArrow: 'gray',
+    showCelebration: false,
+    backLabel: 'Back',
+    replayLabel: 'Replay',
+    instructionsLabel: 'Instructions',
+    scoreLabel: 'Score',
+    celebrationBackLabel: 'Back to menu',
+    onBackPress: () => undefined,
+    onReplayPress: () => undefined,
+    onInstructionsPress: () => undefined,
+    onAdvancePress: () => undefined,
+    onCelebrationBack: () => undefined,
+    icons: ICONS,
+    children: FILLER,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GameShellScreen>;
+
+export const Default: Story = {};
+
+export const InteractionLocked: Story = {
+  args: { interactionLocked: true },
+};
+
+export const AdvanceArrowBlue: Story = {
+  args: {
+    advanceArrow: 'blue',
+    trackerCount: 5,
+    trackerStates: trackers(5),
+    score: 50,
+  },
+};
+
+export const AdvanceArrowHidden: Story = {
+  args: { advanceArrow: 'hidden' },
+};
+
+export const NoInstructions: Story = {
+  args: { showInstructionsButton: false },
+};
+
+export const Celebration: Story = {
+  args: {
+    showCelebration: true,
+    trackerCount: 12,
+    trackerStates: trackers(12),
+    score: 132,
+  },
+};

--- a/libs/alphaTiles/feature-loading/src/LoadingScreen.stories.tsx
+++ b/libs/alphaTiles/feature-loading/src/LoadingScreen.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LoadingScreen } from './LoadingScreen';
+
+const meta: Meta<typeof LoadingScreen> = {
+  title: 'alphaTiles/feature-loading/LoadingScreen',
+  component: LoadingScreen,
+  args: {
+    phase: 'fonts',
+    audioProgress: 0,
+    error: null,
+    labels: {
+      title: 'Loading…',
+      progress: 'Loading audio…',
+      tapToBegin: 'Tap to begin',
+      error: 'Something went wrong',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LoadingScreen>;
+
+export const Fonts: Story = { args: { phase: 'fonts' } };
+export const I18n: Story = { args: { phase: 'i18n' } };
+export const AudioMid: Story = { args: { phase: 'audio', audioProgress: 0.42 } };
+export const AudioComplete: Story = { args: { phase: 'audio', audioProgress: 1 } };
+export const Precompute: Story = { args: { phase: 'precompute' } };
+export const TapToBegin: Story = {
+  args: {
+    phase: 'web-gate',
+    onTapToBegin: () => undefined,
+  },
+};
+export const ErrorState: Story = {
+  args: {
+    phase: 'fonts',
+    error: new Error('Failed to load fonts: bundle missing'),
+  },
+};

--- a/libs/alphaTiles/feature-resources/eslint.config.mjs
+++ b/libs/alphaTiles/feature-resources/eslint.config.mjs
@@ -15,6 +15,8 @@ export default [
             '{projectRoot}/src/**/*.test.tsx',
             '{projectRoot}/src/**/*.spec.ts',
             '{projectRoot}/src/**/*.spec.tsx',
+            '{projectRoot}/src/**/*.stories.tsx',
+            '{projectRoot}/src/**/*.stories.ts',
           ],
         },
       ],

--- a/libs/alphaTiles/feature-resources/src/ResourcesScreen.stories.tsx
+++ b/libs/alphaTiles/feature-resources/src/ResourcesScreen.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ResourcesScreen } from './ResourcesScreen';
+
+const meta: Meta<typeof ResourcesScreen> = {
+  title: 'alphaTiles/feature-resources/ResourcesScreen',
+  component: ResourcesScreen,
+  args: {
+    onBack: () => undefined,
+    isEmpty: false,
+    resources: [
+      { name: 'Teacher guide (PDF)', link: 'https://example.org/guide.pdf', image: '' },
+      { name: 'Reading primer', link: 'https://example.org/primer', image: '' },
+      { name: 'Audio storybook', link: 'https://example.org/audio', image: '' },
+      { name: 'Community website', link: 'https://example.org', image: '' },
+    ],
+    emptyMessage: 'No resources available',
+    onResourceTap: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ResourcesScreen>;
+
+export const WithResources: Story = {};
+
+export const Empty: Story = {
+  args: {
+    isEmpty: true,
+    resources: [],
+  },
+};

--- a/libs/alphaTiles/feature-set-player-name/src/lib/SetPlayerNameScreen.stories.tsx
+++ b/libs/alphaTiles/feature-set-player-name/src/lib/SetPlayerNameScreen.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SetPlayerNameScreen } from './SetPlayerNameScreen';
+
+const ROMAN_KEYS = [
+  ...'abcdefghijklmnopqrstuvwxyz'.split('').map((text) => ({ text, colorHex: '#1565C0' })),
+];
+
+const PLACEHOLDER_AVATARS = Array.from({ length: 12 }, (_, i) => i);
+
+const meta: Meta<typeof SetPlayerNameScreen> = {
+  title: 'alphaTiles/feature-set-player-name/SetPlayerNameScreen',
+  component: SetPlayerNameScreen,
+  args: {
+    name: '',
+    error: '',
+    avatars: PLACEHOLDER_AVATARS,
+    selectedAvatarIndex: 0,
+    keys: ROMAN_KEYS,
+    placeholder: 'Type your name',
+    submitLabel: 'OK',
+    cancelLabel: 'Cancel',
+    onPickAvatar: () => undefined,
+    onKey: () => undefined,
+    onBackspace: () => undefined,
+    onChangeText: () => undefined,
+    onSubmit: () => undefined,
+    onCancel: () => undefined,
+    a11y: {
+      avatarGrid: (i) => `Avatar ${i + 1}`,
+      keyboardDelete: 'Delete',
+      keyboardNext: 'Next',
+      keyboardPrev: 'Previous',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SetPlayerNameScreen>;
+
+export const Empty: Story = {};
+
+export const PartiallyTyped: Story = {
+  args: { name: 'Ann' },
+};
+
+export const WithError: Story = {
+  args: {
+    name: 'Ann',
+    error: 'Name is already taken',
+  },
+};
+
+export const FallbackTextInput: Story = {
+  args: {
+    name: 'Ann',
+    keys: [], // empty keys → Screen falls back to TextInput
+  },
+};

--- a/libs/alphaTiles/feature-share/eslint.config.mjs
+++ b/libs/alphaTiles/feature-share/eslint.config.mjs
@@ -15,6 +15,8 @@ export default [
             '{projectRoot}/src/**/*.test.tsx',
             '{projectRoot}/src/**/*.spec.ts',
             '{projectRoot}/src/**/*.spec.tsx',
+            '{projectRoot}/src/**/*.stories.tsx',
+            '{projectRoot}/src/**/*.stories.ts',
           ],
         },
       ],

--- a/libs/alphaTiles/feature-share/src/ShareScreen.stories.tsx
+++ b/libs/alphaTiles/feature-share/src/ShareScreen.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShareScreen } from './ShareScreen';
+
+const meta: Meta<typeof ShareScreen> = {
+  title: 'alphaTiles/feature-share/ShareScreen',
+  component: ShareScreen,
+  args: {
+    onBack: () => undefined,
+    available: true,
+    url: 'https://alphatilesapps.org/play/eng',
+    instructions: 'Scan this QR code to share this app',
+    shareButtonLabel: 'Share via…',
+    qrAltLabel: 'QR code linking to the app',
+    unavailableMessage: 'Sharing not configured for this pack',
+    onShareTap: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ShareScreen>;
+
+export const Available: Story = {};
+
+export const Unavailable: Story = {
+  args: {
+    available: false,
+    url: '',
+  },
+};

--- a/libs/shared/storybook-host/.storybook/main.ts
+++ b/libs/shared/storybook-host/.storybook/main.ts
@@ -52,11 +52,79 @@ const config: StorybookConfig = {
       files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
     },
     {
+      directory: '../../../alphaTiles/feature-about/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-choose-player/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-brazil/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-chile/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
       directory: '../../../alphaTiles/feature-game-china/src',
       files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
     },
     {
+      directory: '../../../alphaTiles/feature-game-italy/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-japan/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-menu/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-mexico/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
       directory: '../../../alphaTiles/feature-game-myanmar/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-peru/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-romania/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-shell/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-thailand/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-united-states/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-loading/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-resources/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-set-player-name/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-share/src',
       files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
     },
   ],


### PR DESCRIPTION
## Summary

Closes the Storybook coverage gap surfaced in PR #8.

**9 new stories** for every previously-uncovered presenter:

| Lib | Stories |
|---|---|
| `feature-about` | Default, WithSecondaryCredits, NoOptionalLinks |
| `feature-share` | Available, Unavailable |
| `feature-resources` | WithResources, Empty |
| `feature-loading` | Fonts, I18n, AudioMid, AudioComplete, Precompute, TapToBegin, ErrorState |
| `feature-choose-player` | ThreePlayers, Empty, DeleteArmed, DeleteConfirm |
| `feature-set-player-name` | Empty, PartiallyTyped, WithError, FallbackTextInput |
| `feature-game-menu` | (Classic) Default, WithProgress, Paged, NoOptionalControls; (Modern) Default, ManyDoors, Mixed |
| `feature-game-shell` | Default, InteractionLocked, AdvanceArrowBlue, AdvanceArrowHidden, NoInstructions, Celebration |

**Storybook host updated** — `libs/shared/storybook-host/.storybook/main.ts` registers all 18 story-bearing libs (was just `feature-game-china`). Without this every other story file was silently invisible.

**ESLint configs patched** — `feature-about`, `feature-share`, `feature-resources` add `*.stories.tsx`/`.ts` to `@nx/dependency-checks` `ignoredFiles` so stories importing `@storybook/react` don't trigger missing-dep errors.

## Test plan

- [x] `nx run-many -t lint --projects=feature-{about,share,resources,loading,choose-player,set-player-name,game-menu,game-shell}` — clean
- [x] `nx run-many -t test --projects=feature-{about,share,resources,loading,choose-player,set-player-name,game-menu,game-shell}` — clean
- [ ] Manual: open `./nx storybook storybook-host` and visually verify each new story renders. Pending; can't drive a browser from automation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PncmrYBNDuRoNguRXnauLa)_