### PR TITLE
test(storybook-host): register 5 new game libs

### DIFF
--- a/libs/shared/storybook-host/.storybook/main.ts
+++ b/libs/shared/storybook-host/.storybook/main.ts
@@ -72,11 +72,27 @@ const config: StorybookConfig = {
       files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
     },
     {
+      directory: '../../../alphaTiles/feature-game-ecuador/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-georgia/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-iraq/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
       directory: '../../../alphaTiles/feature-game-italy/src',
       files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
     },
     {
       directory: '../../../alphaTiles/feature-game-japan/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-malaysia/src',
       files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
     },
     {
@@ -101,6 +117,10 @@ const config: StorybookConfig = {
     },
     {
       directory: '../../../alphaTiles/feature-game-shell/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
+      directory: '../../../alphaTiles/feature-game-sudan/src',
       files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
     },
     {


### PR DESCRIPTION
## Summary

5 new game libs (`ecuador`, `georgia`, `iraq`, `malaysia`, `sudan`) landed on main in parallel with PR #10. Each has its own stories file but was never added to `libs/shared/storybook-host/.storybook/main.ts`, so its stories were silently invisible.

This is the same gap PR #10 closed for the older libs — same fix.

## Test plan

- One-line additions per lib; no source code changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PncmrYBNDuRoNguRXnauLa)_