### PR TITLE
fix(games): china+japan advance arrow; mexico flake; colombia stories; CI storybook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,3 +36,11 @@ jobs:
       - run: npx nx affected -t lint test --skip-nx-cache
         env:
           NX_NO_CLOUD: true
+
+      # Build the composite Storybook host. Catches story-render regressions
+      # for every game/UI lib (each game's Screen.stories.tsx is bundled).
+      # Always runs (not affected-gated) because storybook-host has no static
+      # imports of game libs — its dep graph is discovered at Vite build time.
+      - run: npx nx run storybook-host:build-storybook --skip-nx-cache
+        env:
+          NX_NO_CLOUD: true

--- a/libs/alphaTiles/feature-game-china/src/ChinaContainer.tsx
+++ b/libs/alphaTiles/feature-game-china/src/ChinaContainer.tsx
@@ -6,7 +6,7 @@
  *
  * Port of China.java — see design.md for the full mapping table.
  */
-import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import type { ImageSourcePropType } from 'react-native';
 import { useLangAssets, usePrecompute } from '@alphaTiles/data-language-assets';
 import { useAudio } from '@alphaTiles/data-audio';
@@ -76,13 +76,6 @@ function ChinaGame({ challengeLevel }: { challengeLevel: number }): React.JSX.El
   const [solvedLines, setSolvedLines] = useState<boolean[]>([false, false, false, false]);
   const [currentWords, setCurrentWords] = useState<CurrentWords | null>(null);
   const [error, setError] = useState<'insufficient-content' | null>(null);
-  const isMountedRef = useRef(true);
-
-  useEffect(() => {
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
 
   const startRound = useCallback(() => {
     const chosen = chooseWords({
@@ -121,9 +114,13 @@ function ChinaGame({ challengeLevel }: { challengeLevel: number }): React.JSX.El
     setError(null);
   }, [chinaData, parseTiles, moves, shell]);
 
-  // One-shot mount kickoff (useMountEffect pattern)
+  // One-shot mount kickoff + wire advance arrow to startRound (spec §Win/Advance).
   useEffect(() => {
     startRound();
+    shell.setOnAdvance(startRound);
+    return () => {
+      shell.setOnAdvance(null);
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -162,18 +159,13 @@ function ChinaGame({ challengeLevel }: { challengeLevel: number }): React.JSX.El
       if (newSolvedLines.every(Boolean)) {
         shell.setInteractionLocked(true);
         audio.playCorrectFinal();
-        shell.incrementPointsAndTracker(true);
-        setTimeout(() => {
-          if (isMountedRef.current) {
-            startRound();
-            shell.setInteractionLocked(false);
-          }
-        }, 1200);
+        // Spec line 83: incrementPointsAndTracker(4) on full-board solve.
+        shell.incrementPointsAndTracker(true, 4);
       }
     },
     [
       shell, blankIndex, board, currentWords, tileMap, placeholderChar,
-      scriptType, audio, startRound,
+      scriptType, audio,
     ],
   );
 

--- a/libs/alphaTiles/feature-game-japan/src/JapanContainer.tsx
+++ b/libs/alphaTiles/feature-game-japan/src/JapanContainer.tsx
@@ -278,9 +278,14 @@ function JapanGame({ challengeLevel }: JapanGameProps): React.JSX.Element {
     });
   }, [assets, parseWordTiles, parseCorrectSyllables, maxTiles, shell]);
 
-  // Mount-only kickoff (useMountEffect pattern)
+  // Mount-only kickoff + wire advance arrow to startRound (spec line 76:
+  // "advance arrow turns blue" on win → tapping it starts a new round).
   useEffect(() => {
     startRound();
+    shell.setOnAdvance(startRound);
+    return () => {
+      shell.setOnAdvance(null);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/libs/alphaTiles/feature-game-mexico/src/setupMexicoBoard.ts
+++ b/libs/alphaTiles/feature-game-mexico/src/setupMexicoBoard.ts
@@ -2,14 +2,21 @@
  * Pure board setup for the Mexico memory game.
  *
  * Port of Mexico.java:chooseMemoryWords + Collections.shuffle:
- * 1. Pick `pairCount` distinct (by wordInLWC) random words via Java's
- *    sanity-counter dedup loop (Mexico.java:162-217). Bails to
- *    insufficient-content after pairCount*3 attempts.
- * 2. Create two CardState entries per word: one TEXT, one IMAGE.
- * 3. Shuffle the result.
+ * 1. Dedupe the pool by `wordInLWC` (Java's i-- retry loop dedupes implicitly),
+ *    bail to insufficient-content if fewer than `pairCount` distinct entries.
+ * 2. Fisher-Yates partial shuffle to pick `pairCount` distinct words.
+ * 3. Create two CardState entries per word: one TEXT, one IMAGE.
+ * 4. Shuffle the result.
+ *
+ * Java port note: the Java loop samples-with-rejection bounded by a
+ * `cardsToSetUp * 3` sanity counter. With `pool.length === pairCount` that
+ * counter sits at the coupon-collector boundary (~50% bail rate), which would
+ * spuriously surface "insufficient content" to users with edge-case packs.
+ * Up-front dedupe + partial shuffle yields the same result set with O(N) work
+ * and zero false-bail probability — preferred over verbatim Java parity.
  *
  * Returns { cards } on success, { error: 'insufficient-content' } when the pool
- * is too small or has too few distinct LWC entries.
+ * has too few distinct LWC entries.
  */
 
 export type CardMode = 'TEXT' | 'IMAGE';
@@ -32,35 +39,29 @@ export function setupMexicoBoard(
   pairCount: number,
   rng: () => number = Math.random,
 ): SetupResult {
-  if (validMatchingWords.length < pairCount) {
+  // Dedupe by wordInLWC — first occurrence wins (matches Java's i-- retry,
+  // which keeps the first sampled entry per LWC and rejects later duplicates).
+  const seenLwc = new Set<string>();
+  const distinctPool: Array<{ wordInLOP: string; wordInLWC: string }> = [];
+  for (const w of validMatchingWords) {
+    if (seenLwc.has(w.wordInLWC)) continue;
+    seenLwc.add(w.wordInLWC);
+    distinctPool.push(w);
+  }
+
+  if (distinctPool.length < pairCount) {
+    // Java goBackToEarth(null) — pool can't supply pairCount distinct LWC entries.
     return { error: 'insufficient-content' };
   }
 
-  // Java chooseMemoryWords (Mexico.java:162-217) parity: pick a random word from the
-  // full pool, reject if its wordInLWC already appears in the deck, retry via i--.
-  // A sanity counter increments every iteration and bails after cardsToSetUp*3 to
-  // avoid infinite loops when the pool has too few distinct LWC entries.
-  const chosen: Array<{ wordInLOP: string; wordInLWC: string }> = [];
-  const seenLwc = new Set<string>();
-  const sanityLimit = pairCount * 3;
-  let sanityCounter = 0;
-
+  // Fisher-Yates partial shuffle: pick `pairCount` distinct words.
   for (let i = 0; i < pairCount; i++) {
-    const candidate = validMatchingWords[Math.floor(rng() * validMatchingWords.length)];
-    const wordAcceptable = !seenLwc.has(candidate.wordInLWC);
-
-    if (wordAcceptable) {
-      seenLwc.add(candidate.wordInLWC);
-      chosen.push(candidate);
-    } else {
-      i--; // Java: retry this slot
-    }
-
-    if (++sanityCounter > sanityLimit) {
-      // Java goBackToEarth(null) — pool can't supply pairCount distinct LWC entries.
-      return { error: 'insufficient-content' };
-    }
+    const j = i + Math.floor(rng() * (distinctPool.length - i));
+    const tmp = distinctPool[i];
+    distinctPool[i] = distinctPool[j];
+    distinctPool[j] = tmp;
   }
+  const chosen = distinctPool.slice(0, pairCount);
 
   // Create pairs
   const pairs: CardState[] = [];

--- a/libs/shared/storybook-host/.storybook/main.ts
+++ b/libs/shared/storybook-host/.storybook/main.ts
@@ -72,6 +72,10 @@ const config: StorybookConfig = {
       files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
     },
     {
+      directory: '../../../alphaTiles/feature-game-colombia/src',
+      files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
+    },
+    {
       directory: '../../../alphaTiles/feature-game-ecuador/src',
       files: '**/*.stories.@(js|jsx|ts|tsx|mdx)',
     },


### PR DESCRIPTION
## Summary

Audited all 17 ported Java games for real runtime bugs. Found 5; fixed all.

### Game bugs

- **china** (`ChinaContainer.tsx`): never wired `setOnAdvance` → spec line 130 says arrow advances; game was unreachable past 1st round in canonical path. Auto-`setTimeout` was masking it but contradicts spec. Also was scoring 1pt instead of spec-mandated 4pts (spec line 83).
- **japan** (`JapanContainer.tsx`): never wired `setOnAdvance` → game stuck after 1st win (no auto-advance fallback even existed). Spec line 76 mandates arrow.
- **mexico** (`setupMexicoBoard.ts`): Java-parity sample-with-rejection loop hit the coupon-collector boundary and bailed ~50% of the time when `pool.length === pairCount` (e.g. CL5 with exactly 10 valid words → "insufficient content" half the time). Replaced with up-front LWC-dedupe + Fisher-Yates partial shuffle — same result set, deterministic, O(N). Pre-existing failing test now passes.

### Storybook coverage / CI

- `feature-game-colombia` was missing from `.storybook/main.ts` → its stories never rendered. Added.
- CI ran lint/test only. Added `nx run storybook-host:build-storybook` step (unconditional, since `storybook-host` has no static imports of game libs so affected-detection misses changes there).

The other 14 games (Brazil, Chile, Ecuador, Georgia, Iraq, Italy, Malaysia, Myanmar, Peru, Romania, Sudan, Thailand, USA + the 4 fixed) audited clean.

## Test plan

- [x] `nx run-many -t lint test --projects="feature-game-*"` — all 19 projects pass
- [x] `nx run feature-game-mexico:test` — previously-flaky `setupMexicoBoard` test now deterministic
- [x] `nx build-storybook storybook-host` — bundles `ColombiaScreen.stories` (was absent before)
- [ ] Manual smoke: load China, complete a round, tap advance arrow → next round starts (no longer relying on removed setTimeout)
- [ ] Manual smoke: load Japan, win, tap advance arrow → next round starts (was previously unreachable)
- [ ] Manual smoke: load Mexico CL5 with exactly 10 valid words → no spurious insufficient-content
- [ ] CI green on the new build-storybook step

---
_Generated by [Claude Code](https://claude.ai/code/session_01U73GXGrdu3GcW4Zi3QzXYZ)_